### PR TITLE
Immediate Publishers

### DIFF
--- a/Documentation/Immediate.md
+++ b/Documentation/Immediate.md
@@ -1,0 +1,125 @@
+Immediate Publishers
+====================
+
+**`ImmediatePublisher` is the protocol for publishers that publish a value or fail, right on subscription.**
+
+```swift
+/// x-------> can fail immediately.
+/// o - - - > can publish one value immediately (and then publish any number
+///           of values, at any time, until the eventual completion).
+protocol ImmediatePublisher: Publisher { }
+```
+
+When you import CombineTraits, many Combine publishers are extended with conformance to `ImmediatePublisher`, such as `Just`, `Fail` and `CurrentValueSubject`. Other publishers are conditionally extended, such as `Publishers.Map` or `Publishers.FlatMap`.
+
+Conversely, some publishers such as `Publishers.Sequence` are not extended with `ImmediatePublisher`, because not all sequences contain a value.
+
+- [AnyImmediatePublisher]: a replacement for `AnyPublisher`
+- [Building Immediate Publishers]
+
+## AnyImmediatePublisher
+
+`AnyImmediatePublisher` is a publisher type that hides details you don’t want to expose across API boundaries. For example, the user of the publisher below knows that it publishes exactly one `String`, no more, no less:
+    
+```swift
+/// 👍 Publishes one name right on subscription
+func namePublisher() -> AnyImmediatePublisher<String, Never>
+```
+
+Compare with the regular `AnyPublisher`, where documentation is the only way to express the "immediate" guarantee:
+
+```swift
+/// 😥 Trust us: this publisher publishes one name right on subscription.
+func namePublisher() -> AnyPublisher<String, Never>
+```
+
+You build an `AnyImmediatePublisher` with the `ImmediatePublisher.eraseToAnyImmediatePublisher()` method. For example:
+
+```swift
+func namePublisher() -> AnyImmediatePublisher<String, Never> {
+    Just("Alice").eraseToAnyImmediatePublisher()
+}
+```
+
+Don't miss [Basic Immediate Publishers] for some handy shortcuts. The above publisher can be written as:
+
+```swift
+func namePublisher() -> AnyImmediatePublisher<String, Never> {
+    .just("Alice")
+}
+```
+
+## Building Immediate Publishers
+
+In order to benefit from the `ImmediatePublisher` protocol, you need a concrete publisher that conforms to this protocol.
+
+There are a few ways to get such a immediate publisher:
+
+- **Compiler-checked immediate publishers** are publishers that conform to the `ImmediatePublisher` protocol. This is the case of `Just` and `Fail`, for example. Some publishers conditionally conform to `ImmediatePublisher`, such as `Publishers.Map`, when the upstream publisher is a immediate publisher.
+    
+    When you define a publisher type that publishes a value or fails, right on subscription, you can turn it into a immediate publisher with an extension:
+    
+    ```swift
+    struct MyImmediatePublisher: Publisher { ... }
+    extension MyImmediatePublisher: ImmediatePublisher { }
+    
+    let immediatePublisher = MyImmediatePublisher().eraseToAnyImmediatePublisher()
+    let cancellable = MyImmediatePublisher().sinkImmediate { result in ... }
+    ```
+
+- **Runtime-checked immediate publishers** are publishers that conform to the `ImmediatePublisher` protocol by checking, at runtime, that an upstream publisher publishes a value or fails, right on subscription.
+    
+    `Publisher.assertImmediate()` returns a immediate publisher that raises a fatal error if the upstream publisher does not honor the contract.
+        
+    For example:
+    
+    ```swift
+    let nameSubject: PassthroughSubject<String, Never> = ...
+    
+    func namePublisher() -> AnyImmediatePublisher<String, Never> {
+        subject.prepend("Unknown").assertImmediate().eraseToAnyImmediatePublisher()
+    }
+    ```
+
+- **Unchecked immediate publishers**: you should only build such a immediate publisher when you are sure that the `ImmediatePublisher` contract is honored by the upstream publisher.
+    
+    For example:
+    
+    ```swift
+    // CORRECT: those publish a value or fail, right on subscription.
+    [1].publisher.uncheckedImmediate()
+    [1, 2].publisher.prefix(1).uncheckedImmediate()
+    
+    // WRONG: does not publish any value, does not fail.
+    Empty().uncheckedImmediate()
+    ```
+    
+    The consequences of using `uncheckedImmediate()` on a publisher that does not publish a value or fail, right on subscription, are undefined.
+
+See also [Basic Immediate Publishers].
+
+### Basic Immediate Publishers
+
+`AnyImmediatePublisher` comes with factory methods that build basic immediate publishers:
+
+```swift
+// Publishes one value, and then completes.
+AnyImmediatePublisher.just(value)
+
+// Fails with the given error.
+AnyImmediatePublisher.fail(error)
+```
+
+They are quite handy:
+
+```swift
+func namePublisher() -> AnyImmediatePublisher<String, Error> {
+    .just("Alice")
+}
+```
+
+
+[AnyImmediatePublisher]: #anyimmediatepublisher
+[Building Immediate Publishers]: #building-immediate-publishers
+[Basic Immediate Publishers]: #basic-immediate-publishers
+[Publisher]: https://developer.apple.com/documentation/combine/publisher

--- a/Documentation/Immediate.md
+++ b/Documentation/Immediate.md
@@ -19,7 +19,7 @@ Conversely, some publishers such as `Publishers.Sequence` are not extended with 
 
 ## AnyImmediatePublisher
 
-`AnyImmediatePublisher` is a publisher type that hides details you don’t want to expose across API boundaries. For example, the user of the publisher below knows that it publishes exactly one `String`, no more, no less:
+`AnyImmediatePublisher` is a publisher type that hides details you don’t want to expose across API boundaries. For example, the user of the publisher below knows that it certainly publishes one `String` right on subscription:
     
 ```swift
 /// 👍 Publishes one name right on subscription

--- a/Documentation/Maybe.md
+++ b/Documentation/Maybe.md
@@ -118,7 +118,7 @@ There are a few ways to get such a maybe publisher:
 
 - **Runtime-checked maybe publishers** are publishers that conform to the `MaybePublisher` protocol by checking, at runtime, that an upstream publisher publishes exactly zero value, or one value, or an error.
     
-    `Publisher.assertMaybe()` returns a maybe publisher that raises a fatal error if the upstream publisher does not publish exactly zero value, or one value, or an error.
+    `Publisher.assertMaybe()` returns a maybe publisher that raises a fatal error if the upstream publisher does not honor the contract.
         
     For example:
     

--- a/Documentation/Maybe.md
+++ b/Documentation/Maybe.md
@@ -21,7 +21,7 @@ Conversely, some publishers such as `Publishers.Sequence` are not extended with 
 
 ## AnyMaybePublisher
 
-`AnyMaybePublisher` is a publisher type that hides details you don’t want to expose across API boundaries. For example, the user of the publisher below knows that it publishes exactly zero or one `String`, no more, no less:
+`AnyMaybePublisher` is a publisher type that hides details you don’t want to expose across API boundaries. For example, the user of the publisher below knows that it certainly publishes exactly zero or one `String`, no more, no less:
     
 ```swift
 /// 👍 Maybe publishes a name

--- a/Documentation/Single.md
+++ b/Documentation/Single.md
@@ -140,7 +140,7 @@ There are a few ways to get such a single publisher:
 
 - **Runtime-checked single publishers** are publishers that conform to the `SinglePublisher` protocol by checking, at runtime, that an upstream publisher publishes exactly one value, or an error.
     
-    `Publisher.assertSingle()` returns a single publisher that raises a fatal error if the upstream publisher does not publish exactly one value, or an error.
+    `Publisher.assertSingle()` returns a single publisher that raises a fatal error if the upstream publisher does not honor the contract.
         
     For example:
     

--- a/Documentation/Single.md
+++ b/Documentation/Single.md
@@ -23,7 +23,7 @@ Conversely, some publishers such as `Publishers.Sequence` are not extended with 
 
 ## AnySinglePublisher
 
-`AnySinglePublisher` is a publisher type that hides details you don’t want to expose across API boundaries. For example, the user of the publisher below knows that it publishes exactly one `String`, no more, no less:
+`AnySinglePublisher` is a publisher type that hides details you don’t want to expose across API boundaries. For example, the user of the publisher below knows that it certainly publishes exactly one `String`, no more, no less:
     
 ```swift
 /// 👍 Publishes exactly one name

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This library provides compiler-checked definition, and subscription, to publishe
 
 **CombineTraits preserves the general ergonomics of Combine.** Your application still deals with regular Combine publishers and operators.
 
-`AnyPublisher` can be replaced with `AnySinglePublisher` or `AnyMaybePublisher`, in order to express which trait a publisher conforms to:
+`AnyPublisher` can be replaced with `AnySinglePublisher`, `AnyMaybePublisher`, or `AnyImmediatePublisher`, in order to express which trait a publisher conforms to:
     
 ```swift
 func refreshPublisher() -> AnySinglePublisher<Void, Error> {

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ This library provides compiler-checked definition, and subscription, to publishe
     --o--|--> can publish one value and complete.
     ```
     
-- **[Immediate Publishers]** publish a value, or fail right on subscription, synchronously, without any delay:
+- **[Immediate Publishers]** publish a value or fail, right on subscription:
     
-    The Combine `Just`, and `CurrentValueSubject` are examples of such publishers.
+    The Combine `Just`, `Fail` and `CurrentValueSubject` are examples of such publishers.
     
     ```
     x-------> can fail immediately.
-    o - - - > can publish one value immediately (and then publish any number of values,
-              at any time, until the eventual completion).
+    o - - - > can publish one value immediately (and then publish any number
+              of values, at any time, until the eventual completion).
     ```
 
 # Documentation
@@ -86,4 +86,5 @@ let cancellable = refreshPublisher().sinkSingle { result in
 [Usage]: #usage
 [Single Publishers]: Documentation/Single.md
 [Maybe Publishers]: Documentation/Maybe.md
+[Immediate]: Documentation/Immediate.md
 [Trait Operators]: Documentation/Operators.md

--- a/README.md
+++ b/README.md
@@ -86,5 +86,5 @@ let cancellable = refreshPublisher().sinkSingle { result in
 [Usage]: #usage
 [Single Publishers]: Documentation/Single.md
 [Maybe Publishers]: Documentation/Maybe.md
-[Immediate]: Documentation/Immediate.md
+[Immediate Publishers]: Documentation/Immediate.md
 [Trait Operators]: Documentation/Operators.md

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ CombineTraits [![Swift 5.3](https://img.shields.io/badge/swift-5.3-orange.svg?st
 
 ## What is this?
 
-[Combine] publishers can publish any number of values before they complete. It is particularly the case of [AnyPublisher], frequently returned by our frameworks or applications.
+[Combine] publishers can publish any number of values, at any time, before they complete. It is particularly the case of [AnyPublisher], frequently returned by our frameworks or applications.
 
-When we deal with publishers that are expected to publish a certain amount of values, no more, no less, it is easy to neglect edge cases such as an early completion, or too many published values. And quite often, the behavior of such publishers is subject to interpretation, imprecise documentation, buggy implementations.
+When we deal with publishers that are expected to publish their values according to a specific pattern, it is easy to neglect edge cases such as late publishing, early completion, too many published values, etc. And quite often, the behavior of such publishers is subject to interpretation, imprecise documentation, or buggy implementations.
 
 This library provides compiler-checked definition, and subscription, to publishers that conform to specific *traits*:
         
@@ -35,12 +35,23 @@ This library provides compiler-checked definition, and subscription, to publishe
     -----|--> can complete without publishing any value.
     --o--|--> can publish one value and complete.
     ```
+    
+- **[Immediate Publishers]** publish a value, or complete right on subscription, synchronously, without any delay:
+    
+    The Combine `Just`, `CurrentValueSubject` and `Publishers.Sequence` are examples of such publishers.
+    
+    ```
+    |-------> can complete immediately.
+    x-------> can fail immediately.
+    o-o---o-> must publish their first value immediately.
+    ```
 
 # Documentation
 
 - [Usage]
 - [Single Publishers]
 - [Maybe Publishers]
+- [Immediate Publishers]
 - [Trait Operators]
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ This library provides compiler-checked definition, and subscription, to publishe
     --o--|--> can publish one value and complete.
     ```
     
-- **[Immediate Publishers]** publish a value, or complete right on subscription, synchronously, without any delay:
+- **[Immediate Publishers]** publish a value, or fail right on subscription, synchronously, without any delay:
     
-    The Combine `Just`, `CurrentValueSubject` and `Publishers.Sequence` are examples of such publishers.
+    The Combine `Just`, and `CurrentValueSubject` are examples of such publishers.
     
     ```
-    |-------> can complete immediately.
     x-------> can fail immediately.
-    o-o---o-> must publish their first value immediately.
+    o - - - > can publish one value immediately (and then publish any number of values,
+              at any time, until the eventual completion).
     ```
 
 # Documentation

--- a/Sources/CombineTraits/Combine+ImmediatePublisher.swift
+++ b/Sources/CombineTraits/Combine+ImmediatePublisher.swift
@@ -82,6 +82,12 @@ where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: Im
 extension Publishers.MergeMany: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
 
+extension Publishers.PrefixUntilOutput: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.PrefixWhile: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
 extension Publishers.Print: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
 
@@ -114,6 +120,9 @@ where Upstream: ImmediatePublisher, NewPublisher: ImmediatePublisher { }
 extension Publishers.TryMap: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
 
+extension Publishers.TryPrefixWhile: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
 extension Publishers.TryRemoveDuplicates: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
 
@@ -130,6 +139,8 @@ extension Publishers.Zip4: ImmediatePublisher
 where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: ImmediatePublisher { }
 
 extension Result.Publisher: ImmediatePublisher { }
+
+extension CurrentValueSubject: ImmediatePublisher { }
 
 extension Deferred: ImmediatePublisher
 where DeferredPublisher: ImmediatePublisher { }

--- a/Sources/CombineTraits/Combine+ImmediatePublisher.swift
+++ b/Sources/CombineTraits/Combine+ImmediatePublisher.swift
@@ -1,0 +1,141 @@
+import Combine
+
+extension Publishers.AssertNoFailure: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.Breakpoint: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.Catch: ImmediatePublisher
+where Upstream: ImmediatePublisher, NewPublisher: ImmediatePublisher { }
+
+extension Publishers.CombineLatest: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher { }
+
+extension Publishers.CombineLatest3: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher { }
+
+extension Publishers.CombineLatest4: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: ImmediatePublisher { }
+
+extension Publishers.Concatenate: ImmediatePublisher
+where Prefix: ImmediatePublisher, Suffix: ImmediatePublisher { }
+
+extension Publishers.Decode: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.Encode: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.First: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.FlatMap: ImmediatePublisher
+where Upstream: ImmediatePublisher, NewPublisher: ImmediatePublisher { }
+
+extension Publishers.HandleEvents: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.Map: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.MapError: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.MapKeyPath: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.MapKeyPath2: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.MapKeyPath3: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+// We can't declare "OR" conformance (Merge is immediate if any upstream publisher is immediate)
+extension Publishers.Merge: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher { }
+
+// We can't declare "OR" conformance (Merge is immediate if any upstream publisher is immediate)
+extension Publishers.Merge3: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher { }
+
+// We can't declare "OR" conformance (Merge is immediate if any upstream publisher is immediate)
+extension Publishers.Merge4: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: ImmediatePublisher { }
+
+// We can't declare "OR" conformance (Merge is immediate if any upstream publisher is immediate)
+extension Publishers.Merge5: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: ImmediatePublisher, E: ImmediatePublisher { }
+
+// We can't declare "OR" conformance (Merge is immediate if any upstream publisher is immediate)
+extension Publishers.Merge6: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: ImmediatePublisher, E: ImmediatePublisher, F: ImmediatePublisher { }
+
+// We can't declare "OR" conformance (Merge is immediate if any upstream publisher is immediate)
+extension Publishers.Merge7: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: ImmediatePublisher, E: ImmediatePublisher, F: ImmediatePublisher, G: ImmediatePublisher { }
+
+// We can't declare "OR" conformance (Merge is immediate if any upstream publisher is immediate)
+extension Publishers.Merge8: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: ImmediatePublisher, E: ImmediatePublisher, F: ImmediatePublisher, G: ImmediatePublisher, H: ImmediatePublisher { }
+
+extension Publishers.MergeMany: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.Print: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.RemoveDuplicates: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.ReplaceEmpty: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.ReplaceError: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.Retry: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.Scan: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.Sequence: ImmediatePublisher { }
+
+extension Publishers.SetFailureType: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.SwitchToLatest: ImmediatePublisher
+where P: ImmediatePublisher, Upstream: ImmediatePublisher { }
+
+extension Publishers.TryCatch: ImmediatePublisher
+where Upstream: ImmediatePublisher, NewPublisher: ImmediatePublisher { }
+
+extension Publishers.TryMap: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.TryRemoveDuplicates: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.TryScan: ImmediatePublisher
+where Upstream: ImmediatePublisher { }
+
+extension Publishers.Zip: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher { }
+
+extension Publishers.Zip3: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher { }
+
+extension Publishers.Zip4: ImmediatePublisher
+where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: ImmediatePublisher { }
+
+extension Result.Publisher: ImmediatePublisher { }
+
+extension Deferred: ImmediatePublisher
+where DeferredPublisher: ImmediatePublisher { }
+
+extension Fail: ImmediatePublisher { }
+
+extension Just: ImmediatePublisher { }
+
+extension Record: ImmediatePublisher { }

--- a/Sources/CombineTraits/Combine+ImmediatePublisher.swift
+++ b/Sources/CombineTraits/Combine+ImmediatePublisher.swift
@@ -19,7 +19,7 @@ extension Publishers.CombineLatest4: ImmediatePublisher
 where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: ImmediatePublisher { }
 
 extension Publishers.Concatenate: ImmediatePublisher
-where Prefix: ImmediatePublisher, Suffix: ImmediatePublisher { }
+where Prefix: ImmediatePublisher { }
 
 extension Publishers.Decode: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
@@ -82,12 +82,6 @@ where A: ImmediatePublisher, B: ImmediatePublisher, C: ImmediatePublisher, D: Im
 extension Publishers.MergeMany: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
 
-extension Publishers.PrefixUntilOutput: ImmediatePublisher
-where Upstream: ImmediatePublisher { }
-
-extension Publishers.PrefixWhile: ImmediatePublisher
-where Upstream: ImmediatePublisher { }
-
 extension Publishers.Print: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
 
@@ -106,8 +100,6 @@ where Upstream: ImmediatePublisher { }
 extension Publishers.Scan: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
 
-extension Publishers.Sequence: ImmediatePublisher { }
-
 extension Publishers.SetFailureType: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
 
@@ -118,9 +110,6 @@ extension Publishers.TryCatch: ImmediatePublisher
 where Upstream: ImmediatePublisher, NewPublisher: ImmediatePublisher { }
 
 extension Publishers.TryMap: ImmediatePublisher
-where Upstream: ImmediatePublisher { }
-
-extension Publishers.TryPrefixWhile: ImmediatePublisher
 where Upstream: ImmediatePublisher { }
 
 extension Publishers.TryRemoveDuplicates: ImmediatePublisher

--- a/Sources/CombineTraits/ImmediatePublisher.swift
+++ b/Sources/CombineTraits/ImmediatePublisher.swift
@@ -4,8 +4,9 @@ import Foundation
 /// `ImmediatePublisher` is the protocol for publishers that publish an element
 /// or complete right on subscription, synchronously, without any delay.
 ///
-/// In the Combine framework, the built-in `Just` and `Publishers.Sequence` are
-/// examples of publishers that conform to `ImmediatePublisher`.
+/// In the Combine framework, the built-in `Just`, `CurrentValueSubject` and
+/// `Publishers.Sequence` are examples of publishers that conform
+/// to `ImmediatePublisher`.
 ///
 /// Conversely, `URLSession.DataTaskPublisher` is not an immediate publisher,
 /// because it is asynchronous.

--- a/Sources/CombineTraits/ImmediatePublisher.swift
+++ b/Sources/CombineTraits/ImmediatePublisher.swift
@@ -4,8 +4,9 @@ import Foundation
 /// `ImmediatePublisher` is the protocol for publishers that publish an element
 /// or fail right on subscription, synchronously, without any delay.
 ///
-/// In the Combine framework, the built-in `Just` and `CurrentValueSubject` are
-/// examples of publishers that conform to `ImmediatePublisher`.
+/// In the Combine framework, the built-in `Just`, `Fail` and
+/// `CurrentValueSubject` are examples of publishers that conform
+/// to `ImmediatePublisher`.
 ///
 /// Conversely, `URLSession.DataTaskPublisher` is not an immediate publisher,
 /// because it is asynchronous.

--- a/Sources/CombineTraits/ImmediatePublisher.swift
+++ b/Sources/CombineTraits/ImmediatePublisher.swift
@@ -1,0 +1,468 @@
+import Combine
+import Foundation
+
+/// `ImmediatePublisher` is the protocol for publishers that publish an element
+/// or complete right on subscription, synchronously, without any delay.
+///
+/// In the Combine framework, the built-in `Just` and `Publishers.Sequence` are
+/// examples of publishers that conform to `ImmediatePublisher`.
+///
+/// Conversely, `URLSession.DataTaskPublisher` is not an immediate publisher,
+/// because it is asynchronous.
+///
+/// # ImmediatePublisher Benefits
+///
+/// Once you have a publisher that conforms to `ImmediatePublisher`, you have
+/// access to two desirable tools:
+///
+/// - An `AnyImmediatePublisher` type that hides details you don’t want to
+///   expose across API boundaries. For example, the user of the publisher below
+///   knows that it publishes its first `String` immediately:
+///
+///         func namePublisher() -> AnyImmediatePublisher<String, Never>
+///
+///   You build an `AnyImmediatePublisher` with the
+///   `eraseToAnyImmediatePublisher()` method:
+///
+///         myImmediatePublisher.eraseToAnyImmediatePublisher()
+///
+/// # Building Immediate Publishers
+///
+/// In order to benefit from the `ImmediatePublisher` protocol, you need a
+/// concrete publisher that conforms to this protocol.
+///
+/// There are a few ways to get such an immediate publisher:
+///
+/// - **Compiler-checked immediate publishers** are publishers that conform to
+///   the `ImmediatePublisher` protocol. This is the case of `Just`, for
+///   example. Some publishers conditionally conform to `ImmediatePublisher`,
+///   such as `Publishers.Map`, when the upstream publisher is an
+///   immediate publisher.
+///
+///   When you define a publisher type that publishes an element or completes
+///   right on subscription, you can turn it into an immediate publisher with
+///   an extension:
+///
+///         struct MyImmediatePublisher: Publisher { ... }
+///         extension MyImmediatePublisher: ImmediatePublisher { }
+///
+/// - **Runtime-checked immediate publishers** are publishers that conform to
+///   the `ImmediatePublisher` protocol by checking, at runtime, that an
+///   upstream publisher publishes an element or completes right
+///   on subscription.
+///
+///     `Publisher.assertImmediate()` returns an immediate publisher that raises
+///     a fatal error if the upstream publisher does not publish an element or
+///     completes right on subscription.
+///
+/// - **Unchecked immediate publishers**: you should only build such an
+///   immediate publisher when you are sure that the `ImmediatePublisher`
+///   contract is honored by the upstream publisher.
+///
+///   For example:
+///
+///         // CORRECT
+///         Just(1).uncheckedImmediate()
+///         Empty().uncheckedImmediate()
+///
+///         // WRONG
+///         Just(1).delay(...).uncheckedImmediate()
+///
+///   The consequences of using `uncheckedImmediate()` on a publisher that does
+///   not publish an element or completes right on subscription.
+///
+/// # Basic Immediate Publishers
+///
+/// `AnyImmediatePublisher` comes with factory methods that build basic
+/// immediatee publishers:
+///
+///         // Completes without publishing any value.
+///         AnyImmediatePublisher.empty()
+///
+///         // Publishes one value, and then completes.
+///         AnyImmediatePublisher.just(value)
+///
+///         // Fails with the given error.
+///         AnyImmediatePublisher.fail(error)
+public protocol ImmediatePublisher: Publisher { }
+
+extension ImmediatePublisher {
+    /// Wraps this immediate publisher with a type eraser.
+    ///
+    /// Use `eraseToAnyImmediatePublisher()` to expose an instance of
+    /// `AnyImmediatePublisher` to the downstream subscriber, rather than this
+    /// publisher’s actual type.
+    ///
+    /// This form of type erasure preserves abstraction across API boundaries,
+    /// such as different modules. When you expose your publishers as the
+    /// `AnyImmediatePublisher` type, you can change the underlying implementation
+    /// over time without affecting existing clients.
+    ///
+    /// - returns: An `AnyImmediatePublisher` wrapping this immediate publisher.
+    public func eraseToAnyImmediatePublisher() -> AnyImmediatePublisher<Output, Failure> {
+        AnyImmediatePublisher(self)
+    }
+}
+
+// MARK: - Checked & Unchecked Immediate Publishers
+
+extension Publisher {
+    /// Checks that the publisher publishes an element or completes right on
+    /// subscription, and turns contract violations into a `ImmediateError`.
+    ///
+    /// See also `Publisher.assertImmediate()`.
+    func checkImmediate() -> CheckImmediatePublisher<Self> {
+        CheckImmediatePublisher(upstream: self)
+    }
+    
+    /// Checks that the publisher publishes an element or completes right on
+    /// subscription, and raises a fatal error if the contract is not honored.
+    ///
+    /// - Parameters:
+    ///   - prefix: A string used at the beginning of the fatal error message.
+    ///   - file: A filename used in the error message. This defaults to `#file`.
+    ///   - line: A line number used in the error message. This defaults to `#line`.
+    /// - Returns: A publisher that raises a fatal error when its upstream publisher fails.
+    public func assertImmediate(_ prefix: String = "", file: StaticString = #file, line: UInt = #line) -> AssertImmediatePublisher<Self> {
+        checkImmediate().assertNoImmediateFailure(prefix, file: file, line: line)
+    }
+    
+    /// Turns a publisher into an immediate publisher, assuming that it
+    /// publishes an element or completes right on subscription.
+    ///
+    /// For example:
+    ///
+    ///     // CORRECT
+    ///     Just(1).uncheckedImmediate()
+    ///     Empty().uncheckedImmediate()
+    ///
+    ///     // WRONG
+    ///     Just(1).delay(...).uncheckedImmediate()
+    ///
+    /// See also `Publisher.assertImmediate()`.
+    ///
+    /// - warning: Violation of the immediate publisher contract are
+    ///   not checked.
+    public func uncheckedImmediate() -> AnyImmediatePublisher<Output, Failure> {
+        AnyImmediatePublisher(unchecked: self)
+    }
+}
+
+/// The type of publishers returned by `Publisher.assertImmediate()`.
+public typealias AssertImmediatePublisher<Upstream: Publisher>
+    = Publishers.MapError<CheckImmediatePublisher<Upstream>, Upstream.Failure>
+
+extension ImmediatePublisher {
+    /// :nodoc:
+    @available(*, deprecated, message: "Publisher is already an immediate publisher")
+    func checkImmediate() -> CheckImmediatePublisher<Self> {
+        CheckImmediatePublisher(upstream: self)
+    }
+    
+    /// :nodoc:
+    @available(*, deprecated, message: "Publisher is already an immediate publisher")
+    public func assertImmediate(_ prefix: String = "", file: StaticString = #file, line: UInt = #line) -> AssertImmediatePublisher<Self> {
+        checkImmediate().assertNoImmediateFailure(prefix, file: file, line: line)
+    }
+    
+    /// :nodoc:
+    @available(*, deprecated, message: "Publisher is already an immediate publisher: use publisher.eraseToAnyImmediatePublisher() instead.")
+    public func uncheckedImmediate() -> AnyImmediatePublisher<Output, Failure> {
+        AnyImmediatePublisher(self)
+    }
+}
+
+protocol _ImmediateError {
+    associatedtype UpstreamFailure: Error
+    func assertUpstreamFailure(_ prefix: String, file: StaticString, line: UInt) -> UpstreamFailure
+}
+
+/// The error for checked immediate publishers.
+public enum ImmediateError<UpstreamFailure: Error>: Error, _ImmediateError {
+    /// Upstream publisher did not publish an element or complete right
+    /// on subscription
+    case notImmediate
+    
+    /// Upstream publisher did complete with an error
+    case upstream(UpstreamFailure)
+    
+    func assertUpstreamFailure(_ prefix: String, file: StaticString, line: UInt) -> UpstreamFailure {
+        switch self {
+        case .notImmediate:
+            fatalError([prefix, "Immediate violation: did not publish an element or complete right on subscription, at \(file):\(line)"].filter { !$0.isEmpty }.joined(separator: " "))
+        case let .upstream(error):
+            return error
+        }
+    }
+}
+
+extension ImmediatePublisher where Failure: _ImmediateError {
+    /// Raises a fatal error when the upstream publisher fails with a violation
+    /// of the `ImmediatePublisher` contract, and otherwise republishes all
+    /// received input.
+    fileprivate func assertNoImmediateFailure(_ prefix: String, file: StaticString, line: UInt)
+    -> Publishers.MapError<Self, Failure.UpstreamFailure>
+    {
+        mapError { error in
+            error.assertUpstreamFailure(prefix, file: file, line: line)
+        }
+    }
+}
+
+// MARK: - AnyImmediatePublisher
+
+/// A publisher that performs type erasure by wrapping another
+/// immediate publisher.
+///
+/// `AnyImmediatePublisher` is a concrete implementation of `ImmediatePublisher`
+/// that has no significant properties of its own, and passes through elements
+/// and completion values from its upstream publisher.
+///
+/// Use `AnyImmediatePublisher` to wrap a publisher whose type has details you
+/// don’t want to expose across API boundaries, such as different modules.
+///
+/// You can use `eraseToAnyImmediatePublisher()` operator to wrap a publisher
+/// with `AnyImmediatePublisher`.
+public struct AnyImmediatePublisher<Output, Failure: Error>: ImmediatePublisher {
+    public typealias Failure = Failure
+    fileprivate let upstream: AnyPublisher<Output, Failure>
+    
+    /// Creates a type-erasing publisher to wrap the unchecked
+    /// immediate publisher.
+    ///
+    /// See `Publisher.uncheckedImmediate()`.
+    fileprivate init<P>(unchecked publisher: P)
+    where P: Publisher, P.Failure == Self.Failure, P.Output == Output
+    {
+        self.upstream = publisher.eraseToAnyPublisher()
+    }
+    
+    /// Creates a type-erasing publisher to wrap the unchecked
+    /// immediate publisher.
+    ///
+    /// See `Publisher.uncheckedImmediate()`.
+    @available(*, deprecated, message: "Publisher is already an immediate publisher: use AnyImmediatePublisher.init(_:) instead.")
+    fileprivate init<P>(unchecked publisher: P)
+    where P: ImmediatePublisher, P.Failure == Self.Failure, P.Output == Output
+    {
+        self.upstream = publisher.eraseToAnyPublisher()
+    }
+    
+    /// Creates a type-erasing publisher to wrap the provided
+    /// immediate publisher.
+    ///
+    /// See `ImmediatePublisher.eraseToAnyImmediatePublisher()`.
+    public init<P>(_ immediatePublisher: P)
+    where P: ImmediatePublisher, P.Failure == Self.Failure, P.Output == Output
+    {
+        self.upstream = immediatePublisher.eraseToAnyPublisher()
+    }
+    
+    public func receive<S>(subscriber: S)
+    where S: Combine.Subscriber, S.Failure == Self.Failure, S.Input == Output
+    {
+        upstream.receive(subscriber: subscriber)
+    }
+}
+
+// MARK: - Canonical Immediate Publishers
+
+extension AnyImmediatePublisher where Failure == Never {
+    /// Creates an `AnyImmediatePublisher` which emits one value, and
+    /// then finishes.
+    public static func just(_ value: Output) -> Self {
+        Just(value).eraseToAnyImmediatePublisher()
+    }
+}
+
+extension AnyImmediatePublisher {
+    /// Creates an `AnyImmediatePublisher` which immediately completes.
+    public static func empty() -> Self {
+        Empty().uncheckedImmediate()
+    }
+    
+    /// Creates an `AnyImmediatePublisher` which immediately completes.
+    public static func empty(outputType: Output.Type, failureType: Failure.Type) -> Self {
+        Empty(outputType: outputType, failureType: failureType).uncheckedImmediate()
+    }
+    
+    /// Creates an `AnyImmediatePublisher` which emits one value, and
+    /// then finishes.
+    public static func just(_ value: Output, failureType: Failure.Type = Self.Failure) -> Self {
+        Just(value)
+            .setFailureType(to: failureType)
+            .eraseToAnyImmediatePublisher()
+    }
+    
+    /// Creates an `AnyImmediatePublisher` that immediately terminates with the
+    /// specified error.
+    public static func fail(_ error: Failure) -> Self {
+        Fail(error: error).eraseToAnyImmediatePublisher()
+    }
+    
+    /// Creates an `AnyImmediatePublisher` that immediately terminates with the
+    /// specified error.
+    public static func fail(_ error: Failure, outputType: Output.Type) -> Self {
+        Fail(outputType: outputType, failure: error).eraseToAnyImmediatePublisher()
+    }
+}
+
+// MARK: - CheckImmediatePublisher
+
+/// An immediate publisher that checks that another publisher publishes an
+/// element or completes right on subscription.
+///
+/// `CheckImmediatePublisher` can fail with a `ImmediateError`:
+///
+/// - `.notImmediate`: Upstream publisher did not publish an element or complete
+///   right on subscription
+///
+/// - `.upstream(error)`: Upstream publisher did complete with an error.
+public struct CheckImmediatePublisher<Upstream: Publisher>: ImmediatePublisher {
+    public typealias Output = Upstream.Output
+    public typealias Failure = ImmediateError<Upstream.Failure>
+    
+    let upstream: Upstream
+    
+    public func receive<S>(subscriber: S)
+    where S: Combine.Subscriber, S.Failure == Self.Failure, S.Input == Output
+    {
+        let subscription = CheckImmediateSubscription(
+            upstream: upstream,
+            downstream: subscriber)
+        subscriber.receive(subscription: subscription)
+    }
+}
+
+private class CheckImmediateSubscription<Upstream: Publisher, Downstream: Subscriber>: Subscription, Subscriber
+where
+    Downstream.Input == Upstream.Output,
+    Downstream.Failure == ImmediateError<Upstream.Failure>
+{
+    private enum State {
+        case waitingForRequest(Upstream, Downstream)
+        case waitingForSubscription(Subscribers.Demand, Downstream)
+        case waitingForImmediate(Subscription, Downstream)
+        case subscribed(Subscription, Downstream)
+        case finished
+    }
+    
+    private var state: State
+    private let lock = NSRecursiveLock()
+    
+    init(
+        upstream: Upstream,
+        downstream: Downstream)
+    {
+        self.state = .waitingForRequest(upstream, downstream)
+    }
+    
+    // MARK: - Subscription
+    
+    func request(_ demand: Subscribers.Demand) {
+        synchronized {
+            switch state {
+            case let .waitingForRequest(upstream, downstream):
+                state = .waitingForSubscription(demand, downstream)
+                upstream.receive(subscriber: self)
+                switch state {
+                case let .waitingForImmediate(subscription, downstream):
+                    state = .finished
+                    subscription.cancel()
+                    downstream.receive(completion: .failure(.notImmediate))
+                case .waitingForRequest, .waitingForSubscription, .subscribed, .finished:
+                    break
+                }
+                
+            case let .waitingForSubscription(currentDemand, downstream):
+                state = .waitingForSubscription(demand + currentDemand, downstream)
+                
+            case let .waitingForImmediate(subscription, _),
+                 let .subscribed(subscription, _):
+                subscription.request(demand)
+                
+            case .finished:
+                break
+            }
+        }
+    }
+    
+    func cancel() {
+        synchronized {
+            switch state {
+            case .waitingForRequest, .waitingForSubscription:
+                state = .finished
+                
+            case let .waitingForImmediate(subscription, _),
+                 let .subscribed(subscription, _):
+                subscription.cancel()
+                state = .finished
+                
+            case .finished:
+                break
+            }
+        }
+    }
+    
+    // MARK: - Subscriber
+    
+    func receive(subscription: Subscription) {
+        synchronized {
+            switch state {
+            case let .waitingForSubscription(currentDemand, downstream):
+                state = .waitingForImmediate(subscription, downstream)
+                subscription.request(currentDemand)
+                
+            case .waitingForRequest, .waitingForImmediate, .subscribed, .finished:
+                break
+            }
+        }
+    }
+    
+    func receive(_ input: Upstream.Output) -> Subscribers.Demand {
+        synchronized {
+            switch state {
+            case let .waitingForRequest(_, downstream),
+                 let .waitingForSubscription(_, downstream),
+                 let .subscribed(_, downstream):
+                return downstream.receive(input)
+                
+            case let .waitingForImmediate(subscription, downstream):
+                state = .subscribed(subscription, downstream)
+                return downstream.receive(input)
+                
+            case .finished:
+                return .none
+            }
+        }
+    }
+    
+    func receive(completion: Subscribers.Completion<Upstream.Failure>) {
+        synchronized {
+            switch state {
+            case let .waitingForRequest(_, downstream),
+                 let .waitingForSubscription(_, downstream),
+                 let .waitingForImmediate(_, downstream),
+                 let .subscribed(_, downstream):
+                state = .finished
+                switch completion {
+                case .finished:
+                    downstream.receive(completion: .finished)
+                case let .failure(error):
+                    downstream.receive(completion: .failure(.upstream(error)))
+                }
+                
+            case .finished:
+                break
+            }
+        }
+    }
+    
+    // MARK: - Private
+    
+    private func synchronized<T>(_ execute: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try execute()
+    }
+}

--- a/Tests/CombineTraitsTests/ImmediatePublisherTests.swift
+++ b/Tests/CombineTraitsTests/ImmediatePublisherTests.swift
@@ -1,0 +1,686 @@
+import Combine
+@testable import CombineTraits
+import XCTest
+
+class ImmediatePublisherTests: XCTestCase {
+    // MARK: - CheckImmediatePublisher
+    
+    func test_CheckImmediatePublisher_Just() throws {
+        let publisher = Just(1).eraseToAnyPublisher().checkImmediate()
+        
+        var completion: Subscribers.Completion<ImmediateError<Never>>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        try withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 1, handler: nil)
+            
+            XCTAssertEqual(value, 1)
+            
+            switch try XCTUnwrap(completion) {
+            case .finished:
+                break
+            case let .failure(error):
+                XCTFail("Unexpected error \(error)")
+            }
+        }
+    }
+    
+    func test_CheckImmediatePublisher_Empty() throws {
+        let publisher = Empty<Int, Never>().checkImmediate()
+        
+        var completion: Subscribers.Completion<ImmediateError<Never>>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        try withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 1, handler: nil)
+            
+            XCTAssertNil(value)
+            
+            switch try XCTUnwrap(completion) {
+            case .finished:
+                break
+            case let .failure(error):
+                XCTFail("Unexpected error \(error)")
+            }
+        }
+    }
+    
+    func test_CheckImmediatePublisher_EmptyWithoutCompletion() throws {
+        let publisher = Empty<Int, Never>(completeImmediately: false).checkImmediate()
+        
+        var completion: Subscribers.Completion<ImmediateError<Never>>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        try withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 0.5, handler: nil)
+            
+            XCTAssertNil(value)
+            
+            switch try XCTUnwrap(completion) {
+            case .finished:
+                break
+            case let .failure(error):
+                switch error {
+                case .notImmediate:
+                    break
+                default:
+                    XCTFail("Unexpected error \(error)")
+                }
+            }
+        }
+    }
+    
+    func test_CheckImmediatePublisher_Fail() throws {
+        struct TestError: Error { }
+        let publisher = Fail<Int, TestError>(error: TestError()).eraseToAnyPublisher().checkImmediate()
+        
+        var completion: Subscribers.Completion<ImmediateError<TestError>>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        try withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 1, handler: nil)
+            
+            XCTAssertNil(value)
+            
+            switch try XCTUnwrap(completion) {
+            case .finished:
+                XCTFail("Expected error")
+            case let .failure(error):
+                switch error {
+                case .upstream:
+                    break
+                default:
+                    XCTFail("Unexpected error \(error)")
+                }
+            }
+        }
+    }
+    
+    func test_CheckImmediatePublisher_ElementThenFailure() throws {
+        struct TestError: Error { }
+        let publisher = Record(output: [1], completion: .failure(TestError()))
+            .eraseToAnyPublisher()
+            .checkImmediate()
+        
+        var completion: Subscribers.Completion<ImmediateError<TestError>>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        try withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 1, handler: nil)
+            
+            XCTAssertEqual(value, 1)
+            
+            switch try XCTUnwrap(completion) {
+            case .finished:
+                XCTFail("Expected error")
+            case let .failure(error):
+                switch error {
+                case .upstream:
+                    break
+                default:
+                    XCTFail("Unexpected error \(error)")
+                }
+            }
+        }
+    }
+    
+    func test_CheckImmediatePublisher_ElementWithoutCompletion() throws {
+        struct TestError: Error { }
+        let subject = CurrentValueSubject<Int, TestError>(1)
+        let publisher = subject.checkImmediate()
+        
+        var completion: Subscribers.Completion<ImmediateError<TestError>>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        expectation.isInverted = true
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 0.5, handler: nil)
+            
+            XCTAssertEqual(value, 1)
+            XCTAssertNil(completion)
+        }
+    }
+    
+    // MARK: - AssertNoImmediateFailurePublisher
+    
+    func test_AssertNoImmediateFailurePublisher_Just() throws {
+        let publisher = Just(1).eraseToAnyPublisher().assertImmediate()
+        
+        var completion: Subscribers.Completion<Never>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        try withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 1, handler: nil)
+            
+            XCTAssertEqual(value, 1)
+            
+            switch try XCTUnwrap(completion) {
+            case .finished:
+                break
+            case let .failure(error):
+                XCTFail("Unexpected error \(error)")
+            }
+        }
+    }
+    
+    func test_AssertNoImmediateFailurePublisher_Fail() throws {
+        struct TestError: Error { }
+        let publisher = Fail<Int, TestError>(error: TestError()).eraseToAnyPublisher().assertImmediate()
+        
+        var completion: Subscribers.Completion<TestError>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        try withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 1, handler: nil)
+            
+            XCTAssertNil(value)
+            
+            switch try XCTUnwrap(completion) {
+            case .finished:
+                XCTFail("Expected error")
+            case .failure:
+                break
+            }
+        }
+    }
+    
+    func test_AssertNoImmediateFailurePublisher_ElementWithoutCompletion() throws {
+        struct TestError: Error { }
+        let subject = CurrentValueSubject<Int, TestError>(1)
+        let publisher = subject.assertImmediate()
+        
+        var completion: Subscribers.Completion<TestError>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        expectation.isInverted = true
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 0.5, handler: nil)
+            
+            XCTAssertEqual(value, 1)
+            XCTAssertNil(completion)
+        }
+    }
+    
+    // MARK: - Canonical Immediate Publishers
+    
+    func test_AnyImmediatePublisher_empty() throws {
+        let publisher = AnyImmediatePublisher<Int, Never>.empty()
+        
+        var completion: Subscribers.Completion<Never>?
+        var value: Int?
+        let expectation = self.expectation(description: "completion")
+        let cancellable = publisher.sink(
+            receiveCompletion: {
+                completion = $0
+                expectation.fulfill()
+            },
+            receiveValue: {
+                value = $0
+            })
+        
+        try withExtendedLifetime(cancellable) {
+            waitForExpectations(timeout: 0.5, handler: nil)
+            
+            XCTAssertNil(value)
+            
+            switch try XCTUnwrap(completion) {
+            case .finished:
+                break
+            case let .failure(error):
+                XCTFail("Unexpected error \(error)")
+            }
+        }
+    }
+    
+    func test_canonical_empty_types() {
+        // The test passes if the test compiles
+        
+        func accept1(_ p: AnyImmediatePublisher<Int, Never>) { }
+        func accept2(_ p: AnyImmediatePublisher<Int, Error>) { }
+        func accept3(_ p: AnyImmediatePublisher<Never, Never>) { }
+        func accept4(_ p: AnyImmediatePublisher<Never, Error>) { }
+        
+        // The various ways to build a publisher...
+        let p1 = AnyImmediatePublisher.empty(outputType: Int.self, failureType: Error.self)
+        let p2 = AnyImmediatePublisher<Int, Error>.empty()
+        
+        // ... build the expected types.
+        accept2(p1)
+        accept2(p2)
+        
+        // Shorthand notation thanks to type inference
+        accept1(.empty())
+        accept2(.empty())
+        accept3(.empty())
+        accept4(.empty())
+    }
+    
+    func test_canonical_just_types() {
+        // The test passes if the test compiles
+        
+        func accept1(_ p: AnyImmediatePublisher<Int, Never>) { }
+        func accept2(_ p: AnyImmediatePublisher<Int, Error>) { }
+        
+        // The various ways to build a publisher...
+        let p1 = AnyImmediatePublisher.just(1)
+        let p2 = AnyImmediatePublisher.just(1, failureType: Error.self)
+        let p3 = AnyImmediatePublisher<Int, Error>.just(1)
+        
+        // ... build the expected types.
+        accept1(p1)
+        accept2(p2)
+        accept2(p3)
+        
+        // Shorthand notation thanks to type inference
+        accept1(.just(1))
+        accept2(.just(1))
+    }
+    
+    func test_canonical_fail_types() {
+        // The test passes if the test compiles
+        
+        struct TestError: Error { }
+        func accept1(_ p: AnyImmediatePublisher<Never, Error>) { }
+        func accept2(_ p: AnyImmediatePublisher<Int, Error>) { }
+        
+        // The various ways to build a publisher...
+        let p1 = AnyImmediatePublisher.fail(TestError() as Error, outputType: Int.self)
+        let p2 = AnyImmediatePublisher<Int, Error>.fail(TestError())
+        
+        // ... build the expected types.
+        accept2(p1)
+        accept2(p2)
+        
+        // Shorthand notation thanks to type inference
+        accept1(.fail(TestError()))
+        accept2(.fail(TestError()))
+    }
+    
+    // MARK: - Immediate Publisher Type Relationships
+    
+    func test_type_relationships() {
+        // This test passes if this test compiles
+        
+        func acceptSomeImmediatePublisher<P: ImmediatePublisher>(_ p: P) {
+            acceptAnyImmediatePublisher(p.eraseToAnyImmediatePublisher())
+        }
+        
+        func acceptAnyImmediatePublisher<Output, Failure>(_ p: AnyImmediatePublisher<Output, Failure>) {
+            acceptSomeImmediatePublisher(p)
+        }
+        
+        func acceptSomePublisher<P: Publisher>(_ p: P) {
+            acceptAnyImmediatePublisher(p.uncheckedImmediate())
+            acceptSomeImmediatePublisher(p.assertImmediate())
+            acceptSomeImmediatePublisher(p.checkImmediate())
+            acceptSomeImmediatePublisher(p.uncheckedImmediate())
+        }
+    }
+    
+    // MARK: - Built-in Immediate Publishers
+    
+    func test_built_in_immediate_publishers() {
+        struct TestError: Error { }
+        
+        let publisher = Just(1).eraseToAnyPublisher()
+        let failingPublisher = publisher.setFailureType(to: Error.self).eraseToAnyPublisher()
+        let immediate = AnyImmediatePublisher<Int, Never>.empty()
+        let failingImmediate = immediate.setFailureType(to: Error.self).eraseToAnyImmediatePublisher()
+        
+        XCTAssertFalse(isImmediate(publisher))
+        XCTAssertFalse(isImmediate(failingPublisher))
+        XCTAssertTrue(isImmediate(immediate))
+        XCTAssertTrue(isImmediate(failingImmediate))
+        
+        // Publishers.AssertNoFailure
+        XCTAssertFalse(isImmediate(failingPublisher.assertNoFailure()))
+        XCTAssertTrue(isImmediate(failingImmediate.assertNoFailure()))
+        
+        // Publishers.Breakpoint
+        XCTAssertFalse(isImmediate(publisher.breakpoint()))
+        XCTAssertFalse(isImmediate(publisher.breakpointOnError()))
+        XCTAssertTrue(isImmediate(immediate.breakpoint()))
+        XCTAssertTrue(isImmediate(immediate.breakpointOnError()))
+        
+        // Publishers.Catch
+        XCTAssertFalse(isImmediate(failingPublisher.catch { _ in publisher }))
+        XCTAssertFalse(isImmediate(failingPublisher.catch { _ in immediate }))
+        XCTAssertFalse(isImmediate(failingImmediate.catch { _ in publisher }))
+        XCTAssertTrue(isImmediate(failingImmediate.catch { _ in immediate }))
+        
+        // Publishers.CombineLatest
+        XCTAssertFalse(isImmediate(publisher.combineLatest(publisher)))
+        XCTAssertFalse(isImmediate(publisher.combineLatest(immediate)))
+        XCTAssertFalse(isImmediate(immediate.combineLatest(publisher)))
+        XCTAssertTrue(isImmediate(immediate.combineLatest(immediate)))
+        
+        // Publishers.CombineLatest3
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest3(publisher, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest3(publisher, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest3(publisher, immediate, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest3(publisher, immediate, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest3(immediate, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest3(immediate, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest3(immediate, immediate, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.CombineLatest3(immediate, immediate, immediate)))
+        
+        // Publishers.CombineLatest4
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(publisher, publisher, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(publisher, publisher, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(publisher, publisher, immediate, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(publisher, publisher, immediate, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(publisher, immediate, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(publisher, immediate, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(publisher, immediate, immediate, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(publisher, immediate, immediate, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(immediate, publisher, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(immediate, publisher, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(immediate, publisher, immediate, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(immediate, publisher, immediate, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(immediate, immediate, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(immediate, immediate, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.CombineLatest4(immediate, immediate, immediate, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.CombineLatest4(immediate, immediate, immediate, immediate)))
+        
+        // Publishers.Concatenate
+        XCTAssertFalse(isImmediate(publisher.append(publisher)))
+        XCTAssertFalse(isImmediate(publisher.append(immediate)))
+        XCTAssertFalse(isImmediate(immediate.append(publisher)))
+        XCTAssertTrue(isImmediate(immediate.append(immediate)))
+        // XCTAssertTrue(isImmediate(publisher.prepend(1)))
+        XCTAssertFalse(isImmediate(publisher.prepend([])))
+        XCTAssertTrue(isImmediate(immediate.prepend(1)))
+        XCTAssertTrue(isImmediate(immediate.prepend([])))
+        
+        // Publishers.Decode
+        struct Decoder<Input>: TopLevelDecoder {
+            func decode<T>(_ type: T.Type, from: Input) throws -> T where T: Decodable { fatalError() }
+        }
+        XCTAssertFalse(isImmediate(publisher.decode(type: String.self, decoder: Decoder())))
+        XCTAssertTrue(isImmediate(immediate.decode(type: String.self, decoder: Decoder())))
+        
+        // Publishers.Encode
+        struct Encoder: TopLevelEncoder {
+            func encode<T>(_ value: T) throws -> Void where T : Encodable { }
+        }
+        XCTAssertFalse(isImmediate(publisher.encode(encoder: Encoder())))
+        XCTAssertTrue(isImmediate(immediate.encode(encoder: Encoder())))
+        
+        // Publishers.First
+        XCTAssertFalse(isImmediate(publisher.first()))
+        XCTAssertTrue(isImmediate(immediate.first()))
+        
+        // Publishers.FlatMap
+        XCTAssertFalse(isImmediate(publisher.flatMap { _ in publisher }))
+        XCTAssertFalse(isImmediate(publisher.flatMap { _ in immediate }))
+        XCTAssertFalse(isImmediate(immediate.flatMap { _ in publisher }))
+        XCTAssertTrue(isImmediate(immediate.flatMap { _ in immediate }))
+        
+        // Publishers.HandleEvents
+        XCTAssertFalse(isImmediate(publisher.handleEvents()))
+        XCTAssertTrue(isImmediate(immediate.handleEvents()))
+        
+        // Publishers.Map
+        XCTAssertFalse(isImmediate(publisher.map { $0 }))
+        XCTAssertTrue(isImmediate(immediate.map { $0 }))
+        
+        // Publishers.MapError
+        XCTAssertFalse(isImmediate(failingPublisher.mapError { $0 }))
+        XCTAssertTrue(isImmediate(failingImmediate.mapError { $0 }))
+        
+        // Publishers.MapKeyPath
+        XCTAssertFalse(isImmediate(publisher.map(\.self)))
+        XCTAssertTrue(isImmediate(immediate.map(\.self)))
+        
+        // Publishers.MapKeyPath2
+        XCTAssertFalse(isImmediate(publisher.map(\.self, \.self)))
+        XCTAssertTrue(isImmediate(immediate.map(\.self, \.self)))
+        
+        // Publishers.MapKeyPath3
+        XCTAssertFalse(isImmediate(publisher.map(\.self, \.self, \.self)))
+        XCTAssertTrue(isImmediate(immediate.map(\.self, \.self, \.self)))
+        
+        // Publishers.Merge
+        XCTAssertFalse(isImmediate(Publishers.Merge(publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge(publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge(immediate, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.Merge(immediate, immediate)))
+        
+        // Publishers.Merge3
+        XCTAssertFalse(isImmediate(Publishers.Merge3(publisher, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge3(publisher, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge3(publisher, immediate, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge3(publisher, immediate, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge3(immediate, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge3(immediate, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge3(immediate, immediate, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.Merge3(immediate, immediate, immediate)))
+        
+        // Publishers.Merge4
+        XCTAssertFalse(isImmediate(Publishers.Merge4(publisher, publisher, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(publisher, publisher, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(publisher, publisher, immediate, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(publisher, publisher, immediate, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(publisher, immediate, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(publisher, immediate, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(publisher, immediate, immediate, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(publisher, immediate, immediate, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(immediate, publisher, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(immediate, publisher, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(immediate, publisher, immediate, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(immediate, publisher, immediate, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(immediate, immediate, publisher, publisher)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(immediate, immediate, publisher, immediate)))
+        XCTAssertFalse(isImmediate(Publishers.Merge4(immediate, immediate, immediate, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.Merge4(immediate, immediate, immediate, immediate)))
+        
+        // Publishers.Merge5
+        XCTAssertFalse(isImmediate(Publishers.Merge5(publisher, publisher, publisher, publisher, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.Merge5(immediate, immediate, immediate, immediate, immediate)))
+        
+        // Publishers.Merge6
+        XCTAssertFalse(isImmediate(Publishers.Merge6(publisher, publisher, publisher, publisher, publisher, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.Merge6(immediate, immediate, immediate, immediate, immediate, immediate)))
+        
+        // Publishers.Merge7
+        XCTAssertFalse(isImmediate(Publishers.Merge7(publisher, publisher, publisher, publisher, publisher, publisher, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.Merge7(immediate, immediate, immediate, immediate, immediate, immediate, immediate)))
+        
+        // Publishers.Merge8
+        XCTAssertFalse(isImmediate(Publishers.Merge8(publisher, publisher, publisher, publisher, publisher, publisher, publisher, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.Merge8(immediate, immediate, immediate, immediate, immediate, immediate, immediate, immediate)))
+        
+        // Publishers.MergeMany
+        XCTAssertFalse(isImmediate(Publishers.MergeMany(publisher, publisher)))
+        XCTAssertTrue(isImmediate(Publishers.MergeMany(immediate, immediate)))
+        
+        // Publishers.Print
+        XCTAssertFalse(isImmediate(publisher.print()))
+        XCTAssertTrue(isImmediate(immediate.print()))
+        
+        // Publishers.RemoveDuplicates
+        XCTAssertFalse(isImmediate(publisher.removeDuplicates()))
+        XCTAssertTrue(isImmediate(immediate.removeDuplicates()))
+        
+        // Publishers.ReplaceEmpty
+        XCTAssertFalse(isImmediate(publisher.replaceEmpty(with: 1)))
+        XCTAssertTrue(isImmediate(immediate.replaceEmpty(with: 1)))
+        
+        // Publishers.ReplaceError
+        XCTAssertFalse(isImmediate(failingPublisher.replaceError(with: 1)))
+        XCTAssertTrue(isImmediate(failingImmediate.replaceError(with: 1)))
+        
+        // Publishers.Retry
+        XCTAssertFalse(isImmediate(failingPublisher.retry(1)))
+        XCTAssertTrue(isImmediate(failingImmediate.retry(1)))
+        
+        // Publishers.Scan
+        XCTAssertFalse(isImmediate(publisher.scan(()) { _, _ in }))
+        XCTAssertTrue(isImmediate(immediate.scan(()) { _, _ in }))
+        
+        // Publishers.Sequence
+        XCTAssertTrue(isImmediate([1].publisher))
+        
+        // Publishers.SetFailureType
+        XCTAssertFalse(isImmediate(publisher.setFailureType(to: Error.self)))
+        XCTAssertTrue(isImmediate(immediate.setFailureType(to: Error.self)))
+        
+        // Publishers.SwitchToLatest
+        XCTAssertFalse(isImmediate(Just(publisher).eraseToAnyPublisher().switchToLatest()))
+        XCTAssertFalse(isImmediate(Just(immediate).eraseToAnyPublisher().switchToLatest()))
+        XCTAssertFalse(isImmediate(Just(publisher).switchToLatest()))
+        XCTAssertTrue(isImmediate(Just(immediate).switchToLatest()))
+        
+        // Publishers.TryCatch
+        XCTAssertFalse(isImmediate(failingPublisher.tryCatch { _ in publisher }))
+        XCTAssertFalse(isImmediate(failingPublisher.tryCatch { _ in immediate }))
+        XCTAssertFalse(isImmediate(failingImmediate.tryCatch { _ in publisher }))
+        XCTAssertTrue(isImmediate(failingImmediate.tryCatch { _ in immediate }))
+        
+        // Publishers.TryMap
+        XCTAssertFalse(isImmediate(publisher.tryMap { $0 }))
+        XCTAssertTrue(isImmediate(immediate.tryMap { $0 }))
+
+        // Publishers.TryRemoveDuplicates
+        XCTAssertFalse(isImmediate(publisher.tryRemoveDuplicates(by: <)))
+        XCTAssertTrue(isImmediate(immediate.tryRemoveDuplicates(by: <)))
+        
+        // Publishers.TryScan
+        XCTAssertFalse(isImmediate(publisher.tryScan(()) { _, _ in }))
+        XCTAssertTrue(isImmediate(immediate.tryScan(()) { _, _ in }))
+
+        // Publishers.Zip
+        XCTAssertFalse(isImmediate(publisher.zip(publisher)))
+        XCTAssertFalse(isImmediate(publisher.zip(immediate)))
+        XCTAssertFalse(isImmediate(immediate.zip(publisher)))
+        XCTAssertTrue(isImmediate(immediate.zip(immediate)))
+        
+        // Publishers.Zip3
+        XCTAssertFalse(isImmediate(publisher.zip(publisher, publisher)))
+        XCTAssertFalse(isImmediate(publisher.zip(publisher, immediate)))
+        XCTAssertFalse(isImmediate(publisher.zip(immediate, publisher)))
+        XCTAssertFalse(isImmediate(publisher.zip(immediate, immediate)))
+        XCTAssertFalse(isImmediate(immediate.zip(publisher, publisher)))
+        XCTAssertFalse(isImmediate(immediate.zip(publisher, immediate)))
+        XCTAssertFalse(isImmediate(immediate.zip(immediate, publisher)))
+        XCTAssertTrue(isImmediate(immediate.zip(immediate, immediate)))
+        
+        // Publishers.Zip4
+        XCTAssertFalse(isImmediate(publisher.zip(publisher, publisher, publisher)))
+        XCTAssertFalse(isImmediate(publisher.zip(publisher, publisher, immediate)))
+        XCTAssertFalse(isImmediate(publisher.zip(publisher, immediate, publisher)))
+        XCTAssertFalse(isImmediate(publisher.zip(publisher, immediate, immediate)))
+        XCTAssertFalse(isImmediate(publisher.zip(immediate, publisher, publisher)))
+        XCTAssertFalse(isImmediate(publisher.zip(immediate, publisher, immediate)))
+        XCTAssertFalse(isImmediate(publisher.zip(immediate, immediate, publisher)))
+        XCTAssertFalse(isImmediate(publisher.zip(immediate, immediate, immediate)))
+        XCTAssertFalse(isImmediate(immediate.zip(publisher, publisher, publisher)))
+        XCTAssertFalse(isImmediate(immediate.zip(publisher, publisher, immediate)))
+        XCTAssertFalse(isImmediate(immediate.zip(publisher, immediate, publisher)))
+        XCTAssertFalse(isImmediate(immediate.zip(publisher, immediate, immediate)))
+        XCTAssertFalse(isImmediate(immediate.zip(immediate, publisher, publisher)))
+        XCTAssertFalse(isImmediate(immediate.zip(immediate, publisher, immediate)))
+        XCTAssertFalse(isImmediate(immediate.zip(immediate, immediate, publisher)))
+        XCTAssertTrue(isImmediate(immediate.zip(immediate, immediate, immediate)))
+
+        // Result.Publisher
+        XCTAssertTrue(isImmediate(Result<Int, Error>.success(1).publisher))
+
+        // Deferred
+        XCTAssertFalse(isImmediate(Deferred { publisher }))
+        XCTAssertTrue(isImmediate(Deferred { immediate }))
+
+        // Fail
+        XCTAssertTrue(isImmediate(Fail<Int, Error>(error: TestError())))
+
+        // Just
+        XCTAssertTrue(isImmediate(Just(1)))
+
+        // Record
+        XCTAssertTrue(isImmediate(Record(output: [1], completion: .failure(TestError()))))
+    }
+}
+
+private func isImmediate<P: Publisher>(_ p: P) -> Bool { false }
+private func isImmediate<P: ImmediatePublisher>(_ p: P) -> Bool { true }

--- a/Tests/CombineTraitsTests/ImmediatePublisherTests.swift
+++ b/Tests/CombineTraitsTests/ImmediatePublisherTests.swift
@@ -575,6 +575,16 @@ class ImmediatePublisherTests: XCTestCase {
         XCTAssertFalse(isImmediate(Publishers.MergeMany(publisher, publisher)))
         XCTAssertTrue(isImmediate(Publishers.MergeMany(immediate, immediate)))
         
+        // Publishers.PrefixUntilOutput
+        XCTAssertFalse(isImmediate(publisher.prefix(untilOutputFrom: publisher)))
+        XCTAssertFalse(isImmediate(publisher.prefix(untilOutputFrom: immediate)))
+        XCTAssertTrue(isImmediate(immediate.prefix(untilOutputFrom: publisher)))
+        XCTAssertTrue(isImmediate(immediate.prefix(untilOutputFrom: immediate)))
+        
+        // Publishers.PrefixWhile
+        XCTAssertFalse(isImmediate(publisher.prefix(while: { _ in true })))
+        XCTAssertTrue(isImmediate(immediate.prefix(while: { _ in true })))
+        
         // Publishers.Print
         XCTAssertFalse(isImmediate(publisher.print()))
         XCTAssertTrue(isImmediate(immediate.print()))
@@ -621,7 +631,11 @@ class ImmediatePublisherTests: XCTestCase {
         // Publishers.TryMap
         XCTAssertFalse(isImmediate(publisher.tryMap { $0 }))
         XCTAssertTrue(isImmediate(immediate.tryMap { $0 }))
-
+        
+        // Publishers.TryPrefixWhile
+        XCTAssertFalse(isImmediate(publisher.tryPrefix(while: { _ in true })))
+        XCTAssertTrue(isImmediate(immediate.tryPrefix(while: { _ in true })))
+        
         // Publishers.TryRemoveDuplicates
         XCTAssertFalse(isImmediate(publisher.tryRemoveDuplicates(by: <)))
         XCTAssertTrue(isImmediate(immediate.tryRemoveDuplicates(by: <)))
@@ -629,7 +643,7 @@ class ImmediatePublisherTests: XCTestCase {
         // Publishers.TryScan
         XCTAssertFalse(isImmediate(publisher.tryScan(()) { _, _ in }))
         XCTAssertTrue(isImmediate(immediate.tryScan(()) { _, _ in }))
-
+        
         // Publishers.Zip
         XCTAssertFalse(isImmediate(publisher.zip(publisher)))
         XCTAssertFalse(isImmediate(publisher.zip(immediate)))
@@ -663,20 +677,23 @@ class ImmediatePublisherTests: XCTestCase {
         XCTAssertFalse(isImmediate(immediate.zip(immediate, publisher, immediate)))
         XCTAssertFalse(isImmediate(immediate.zip(immediate, immediate, publisher)))
         XCTAssertTrue(isImmediate(immediate.zip(immediate, immediate, immediate)))
-
+        
         // Result.Publisher
         XCTAssertTrue(isImmediate(Result<Int, Error>.success(1).publisher))
-
+        
         // Deferred
         XCTAssertFalse(isImmediate(Deferred { publisher }))
         XCTAssertTrue(isImmediate(Deferred { immediate }))
-
+        
+        // CurrentValueSubject
+        XCTAssertTrue(isImmediate(CurrentValueSubject<Int, Error>(1)))
+        
         // Fail
         XCTAssertTrue(isImmediate(Fail<Int, Error>(error: TestError())))
-
+        
         // Just
         XCTAssertTrue(isImmediate(Just(1)))
-
+        
         // Record
         XCTAssertTrue(isImmediate(Record(output: [1], completion: .failure(TestError()))))
     }

--- a/Tests/CombineTraitsTests/ImmediatePublisherTests.swift
+++ b/Tests/CombineTraitsTests/ImmediatePublisherTests.swift
@@ -266,7 +266,9 @@ class ImmediatePublisherTests: XCTestCase {
     func test_AssertNoImmediateFailurePublisher_ElementWithoutCompletion() throws {
         struct TestError: Error { }
         let subject = CurrentValueSubject<Int, TestError>(1)
-        let publisher = subject.assertImmediate()
+        let publisher = subject
+            .eraseToAnyPublisher()
+            .assertImmediate()
         
         var completion: Subscribers.Completion<TestError>?
         var value: Int?

--- a/Tests/CombineTraitsTests/MaybePublisherTests.swift
+++ b/Tests/CombineTraitsTests/MaybePublisherTests.swift
@@ -584,9 +584,9 @@ class MaybePublisherTests: XCTestCase {
         }
     }
     
-    // MARK: - Built-in Maybes
+    // MARK: - Built-in Maybe Publishers
     
-    func test_built_in_maybes() {
+    func test_built_in_maybe_publishers() {
         struct TestError: Error { }
         
         let publisher = [1, 2, 3].publisher.eraseToAnyPublisher()
@@ -613,7 +613,9 @@ class MaybePublisherTests: XCTestCase {
         
         // Publishers.Breakpoint
         XCTAssertFalse(isMaybe(publisher.breakpoint()))
+        XCTAssertFalse(isMaybe(publisher.breakpointOnError()))
         XCTAssertTrue(isMaybe(maybe.breakpoint()))
+        XCTAssertTrue(isMaybe(maybe.breakpointOnError()))
         
         // Publishers.Catch
         XCTAssertFalse(isMaybe(failingPublisher.catch { _ in publisher }))

--- a/Tests/CombineTraitsTests/SinglePublisherTests.swift
+++ b/Tests/CombineTraitsTests/SinglePublisherTests.swift
@@ -498,9 +498,9 @@ class SinglePublisherTests: XCTestCase {
         }
     }
     
-    // MARK: - Built-in Maybes
+    // MARK: - Built-in Single Publishers
     
-    func test_built_in_maybes() {
+    func test_built_in_single_publishers() {
         struct TestError: Error { }
         
         let publisher = [1, 2, 3].publisher.eraseToAnyPublisher()
@@ -540,8 +540,11 @@ class SinglePublisherTests: XCTestCase {
         
         // Publishers.Breakpoint
         XCTAssertFalse(isSingle(publisher.breakpoint()))
+        XCTAssertFalse(isSingle(publisher.breakpointOnError()))
         XCTAssertFalse(isSingle(maybe.breakpoint()))
+        XCTAssertFalse(isSingle(maybe.breakpointOnError()))
         XCTAssertTrue(isSingle(single.breakpoint()))
+        XCTAssertTrue(isSingle(single.breakpointOnError()))
         
         // Publishers.Catch
         XCTAssertFalse(isSingle(failingPublisher.catch { _ in publisher }))


### PR DESCRIPTION
`ImmediatePublisher` is the protocol for publishers that publish a value or fail, right on subscription:

```swift
/// x-------> can fail immediately.
/// o - - - > can publish one value immediately (and then publish any number
///           of values, at any time, until the eventual completion).
protocol ImmediatePublisher: Publisher { }
```

When you are given such a publisher, you know that you do not have to deal with a waiting state.